### PR TITLE
Add standalone blog pages with shared styling

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,342 @@
+:root {
+  color-scheme: light dark;
+  --background: #f9fafb;
+  --foreground: #111827;
+  --accent: #111827;
+  --accent-foreground: #f9fafb;
+  --muted: #6b7280;
+  --card: #ffffff;
+  --card-border: rgba(17, 24, 39, 0.08);
+  --radius: 18px;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--background);
+  color: var(--foreground);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+header {
+  padding: clamp(2.5rem, 6vw, 4rem) clamp(1rem, 6vw, 5rem) clamp(1.5rem, 5vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+header nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.brand {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.875rem;
+}
+
+.subscribe {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-foreground);
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.subscribe:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(17, 24, 39, 0.14);
+  text-decoration: none;
+}
+
+.hero {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 780px;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 6vw, 3.2rem);
+  line-height: 1.15;
+  letter-spacing: -0.015em;
+}
+
+.hero p {
+  margin: 0;
+  color: var(--muted);
+  font-size: clamp(1rem, 2.4vw, 1.15rem);
+}
+
+main {
+  padding: 0 clamp(1rem, 6vw, 5rem) clamp(4rem, 10vw, 6rem);
+}
+
+.grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+article {
+  background: var(--card);
+  border-radius: var(--radius);
+  border: 1px solid var(--card-border);
+  padding: 1.75rem;
+  display: grid;
+  gap: 0.75rem;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+  scroll-margin-top: 5rem;
+}
+
+article:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 42px rgba(15, 23, 42, 0.12);
+}
+
+article h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+article time {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+article p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.read-more {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.read-more svg {
+  width: 1rem;
+  height: 1rem;
+  transition: transform 150ms ease;
+}
+
+.read-more:hover svg {
+  transform: translateX(2px);
+}
+
+.keywords {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.keyword {
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+  background: rgba(17, 24, 39, 0.06);
+  font-size: 0.85rem;
+  color: var(--foreground);
+}
+
+.section-intro {
+  margin-top: clamp(3rem, 9vw, 5rem);
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  max-width: 780px;
+}
+
+.section-intro h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 5vw, 2.4rem);
+}
+
+footer {
+  padding: clamp(2rem, 6vw, 3rem) clamp(1rem, 6vw, 5rem) 3rem;
+  display: grid;
+  gap: 0.5rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.bangla {
+  font-weight: 500;
+  color: var(--foreground);
+}
+
+.article-page main {
+  display: grid;
+  gap: clamp(2rem, 6vw, 3rem);
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.breadcrumbs a {
+  color: var(--muted);
+}
+
+.article-hero {
+  display: grid;
+  gap: 0.75rem;
+  padding: clamp(1.5rem, 5vw, 2.5rem);
+  background: var(--card);
+  border-radius: var(--radius);
+  border: 1px solid var(--card-border);
+}
+
+.article-hero h1 {
+  margin: 0;
+  font-size: clamp(2.1rem, 5vw, 2.8rem);
+}
+
+.article-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.toc {
+  background: var(--card);
+  border-radius: var(--radius);
+  border: 1px solid var(--card-border);
+  padding: clamp(1.25rem, 4vw, 1.75rem);
+}
+
+.toc h2 {
+  margin: 0 0 0.75rem 0;
+  font-size: 1.1rem;
+}
+
+.toc ol {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.article-body {
+  display: grid;
+  gap: clamp(1.25rem, 4vw, 1.75rem);
+}
+
+.article-body section,
+.article-body p,
+.article-body ul,
+.article-body ol {
+  margin: 0;
+}
+
+.article-body ul,
+.article-body ol {
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.article-body pre {
+  overflow-x: auto;
+  margin: 0;
+  background: rgba(17, 24, 39, 0.08);
+  padding: 1rem;
+  border-radius: 10px;
+  font-size: 0.95rem;
+}
+
+.article-body code {
+  background: rgba(17, 24, 39, 0.08);
+  border-radius: 6px;
+  padding: 0.2rem 0.4rem;
+  font-family: "Fira Code", "Geist Mono", monospace;
+}
+
+.note-box {
+  background: rgba(17, 24, 39, 0.06);
+  border-left: 4px solid var(--accent);
+  padding: 1rem 1.2rem;
+  border-radius: 12px;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #020617;
+    --foreground: #f8fafc;
+    --accent: #f8fafc;
+    --accent-foreground: #020617;
+    --muted: #cbd5f5;
+    --card: rgba(15, 23, 42, 0.6);
+    --card-border: rgba(248, 250, 252, 0.1);
+  }
+
+  article,
+  .article-hero,
+  .toc {
+    background: linear-gradient(145deg, rgba(15, 23, 42, 0.72), rgba(2, 6, 23, 0.88));
+  }
+
+  .article-body pre,
+  .article-body code,
+  .note-box,
+  .keyword {
+    background: rgba(248, 250, 252, 0.08);
+    color: var(--accent-foreground);
+  }
+
+  .keyword {
+    background: rgba(248, 250, 252, 0.1);
+  }
+}

--- a/blog/ai-writing-workflow.html
+++ b/blog/ai-writing-workflow.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AI Writing Workflow for Developers | Sheikh Coders Blog</title>
+    <meta
+      name="description"
+      content="Pair AI with your voice: plan prompts, review drafts, and publish bilingual documentation without losing clarity."
+    />
+    <meta
+      name="keywords"
+      content="AI writing workflow, developer documentation, Bangla AI guide, prompt library, technical writing checklist, CI grammar checks"
+    />
+    <meta name="author" content="Sheikh Coders" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://sheikhcoders.github.io/blog/ai-writing-workflow.html" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/ai-writing-workflow.html" hreflang="x-default" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/ai-writing-workflow.html" hreflang="en" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/ai-writing-workflow.html#bangla" hreflang="bn" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="AI Writing Workflow for Developers" />
+    <meta
+      property="og:description"
+      content="Develop a prompt-first, review-heavy AI writing workflow with bilingual examples for engineering teams."
+    />
+    <meta property="og:url" content="https://sheikhcoders.github.io/blog/ai-writing-workflow.html" />
+    <meta property="og:image" content="https://sheikhcoders.github.io/assets/cover.svg" />
+    <meta property="og:site_name" content="Sheikh Coders" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="bn_BD" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="AI Writing Workflow for Developers" />
+    <meta
+      name="twitter:description"
+      content="Structure prompts, review AI drafts, and automate grammar checks with bilingual documentation tips."
+    />
+    <meta name="twitter:image" content="https://sheikhcoders.github.io/assets/cover.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "AI Writing Workflow for Developers",
+        "inLanguage": ["en", "bn"],
+        "author": {
+          "@type": "Person",
+          "name": "Sheikh Coders"
+        },
+        "datePublished": "2024-04-12",
+        "dateModified": "2024-04-12",
+        "mainEntityOfPage": "https://sheikhcoders.github.io/blog/ai-writing-workflow.html",
+        "image": "https://sheikhcoders.github.io/assets/cover.svg",
+        "publisher": {
+          "@type": "Organization",
+          "name": "Sheikh Coders",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sheikhcoders.github.io/assets/cover.svg"
+          }
+        },
+        "description": "Plan prompts, review AI drafts, and publish bilingual developer documentation with quality gates."
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://sheikhcoders.github.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Blog",
+            "item": "https://sheikhcoders.github.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "AI Writing Workflow for Developers"
+          }
+        ]
+      }
+    </script>
+  </head>
+  <body class="article-page">
+    <header>
+      <nav>
+        <a class="brand" href="../index.html">Sheikh Coders</a>
+        <a class="subscribe" href="mailto:hello@sheikhcoders.com">Stay in the Loop</a>
+      </nav>
+      <div class="hero">
+        <h1>AI Writing Workflow for Developers</h1>
+        <p lang="en">Co-create documentation with AI while keeping tone, accuracy, and accountability intact.</p>
+        <p class="bangla" lang="bn">এআই-কে সাথে নিয়ে ডকুমেন্টেশন লিখুন কিন্তু টোন, নির্ভুলতা ও দায়বদ্ধতা অক্ষুণ্ণ রাখুন।</p>
+      </div>
+    </header>
+    <main>
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../index.html">Home</a>
+        <span aria-hidden="true">/</span>
+        <a href="../index.html">Blog</a>
+        <span aria-hidden="true">/</span>
+        <span>AI Writing Workflow</span>
+      </nav>
+      <section class="article-hero">
+        <div class="article-meta">
+          <time datetime="2024-04-12">12 Apr 2024</time>
+          <span aria-hidden="true">•</span>
+          <span>4 minute read</span>
+          <span aria-hidden="true">•</span>
+          <span>English &amp; Bangla</span>
+        </div>
+        <p lang="en">
+          Treat AI as a pair-programmer for words. Define constraints, review outputs like pull requests, and publish in a shared
+          knowledge base.
+        </p>
+        <p class="bangla" id="bangla" lang="bn">
+          এআই-কে শব্দের পেয়ার প্রোগ্রামার ভাবুন। সীমা নির্ধারণ করুন, আউটপুটকে পুল রিকুয়েস্টের মতো রিভিউ করুন এবং শেয়ার্ড নলেজ বেসে সংরক্ষণ করুন।
+        </p>
+      </section>
+      <aside class="toc" aria-label="Table of contents">
+        <h2>Quick navigation</h2>
+        <ol>
+          <li><a href="#prompt-design">Prompt design fundamentals</a></li>
+          <li><a href="#review-loop">Review &amp; accountability</a></li>
+          <li><a href="#distribution">Distribution &amp; automation</a></li>
+        </ol>
+      </aside>
+      <article class="article-body">
+        <section id="prompt-design">
+          <h2>Prompt design fundamentals</h2>
+          <p lang="en">
+            Specify reader level, tone, scope, and mandatory sections. Attach snippets of existing docs so AI mirrors terminology. Keep a prompt
+            library organised by output type: changelog, release notes, onboarding, API how-to.
+          </p>
+          <p class="bangla" lang="bn">
+            পাঠকের স্তর, টোন, পরিধি ও আবশ্যিক অংশ নির্দিষ্ট করুন। বিদ্যমান ডক থেকে উদ্ধৃতি দিলে এআই একই টার্মিনোলজি ব্যবহার করে। আউটপুট টাইপ অনুযায়ী প্রম্পট লাইব্রেরি সাজিয়ে
+            রাখুন।
+          </p>
+          <ul>
+            <li lang="en">Use numbered steps so AI responses are easy to skim during review.</li>
+            <li class="bangla" lang="bn">রিভিউয়ের সময় দ্রুত পড়ার জন্য প্রম্পটে নম্বরযুক্ত ধাপ ব্যবহার করুন।</li>
+            <li lang="en">Provide bilingual context if the final deliverable needs Bangla phrases.</li>
+            <li class="bangla" lang="bn">যদি চূড়ান্ত আউটপুটে বাংলা প্রয়োজন হয় তবে প্রম্পটে আগেই দ্বিভাষিক কনটেক্সট দিন।</li>
+          </ul>
+        </section>
+        <section id="review-loop">
+          <h2>Review &amp; accountability</h2>
+          <p lang="en">
+            Treat AI drafts like a junior teammate’s pull request. Highlight uncertain segments, add citations, and commit revisions under a
+            dedicated branch. Tag AI-generated commits for transparent history.
+          </p>
+          <p class="bangla" lang="bn">
+            এআই ড্রাফটকে জুনিয়র সহকর্মীর পুল রিকুয়েস্টের মতো দেখুন। অনিশ্চিত অংশ হাইলাইট করুন, উদ্ধৃতি যোগ করুন এবং আলাদা ব্রাঞ্চে সংশোধন কমিট করুন। AI-জনিত কমিট ট্যাগ করুন।
+          </p>
+          <div class="note-box" lang="en">
+            Pair reviews with a style checklist: voice, tense, inclusive language, and terminology. Reject drafts that fail two or more
+            criteria.
+          </div>
+          <div class="note-box bangla" lang="bn">
+            রিভিউয়ের সাথে স্টাইল চেকলিস্ট যুক্ত করুন: ভয়েস, কাল, অন্তর্ভুক্তিমূলক ভাষা ও টার্মিনোলজি। দুইটির বেশি মানদণ্ডে ব্যর্থ ড্রাফট পুনরায় লিখুন।
+          </div>
+          <ul>
+            <li lang="en">Capture reviewer questions in comment threads for future prompt improvements.</li>
+            <li class="bangla" lang="bn">ভবিষ্যৎ প্রম্পট উন্নতির জন্য রিভিউয়ারের প্রশ্ন মন্তব্যে ধরে রাখুন।</li>
+            <li lang="en">Sign off bilingual docs with both technical and localisation reviewers.</li>
+            <li class="bangla" lang="bn">দ্বিভাষিক ডকের অনুমোদনে টেকনিক্যাল ও লোকালাইজেশন রিভিউয়ার যুক্ত করুন।</li>
+          </ul>
+        </section>
+        <section id="distribution">
+          <h2>Distribution &amp; automation</h2>
+          <p lang="en">
+            Publish final docs to a shared knowledge base with tagging for sprint, component, and audience. Automate grammar checks via CI to
+            enforce consistency across repositories.
+          </p>
+          <p class="bangla" lang="bn">
+            চূড়ান্ত ডক শেয়ার্ড নলেজ বেসে স্প্রিন্ট, কম্পোনেন্ট ও শ্রোতাভিত্তিক ট্যাগ সহ প্রকাশ করুন। সব রেপোতে ধারাবাহিকতা আনতে CI দিয়ে গ্রামার চেক স্বয়ংক্রিয় করুন।
+          </p>
+          <ul>
+            <li lang="en">Schedule quarterly audits to refresh screenshots and code snippets.</li>
+            <li class="bangla" lang="bn">স্ক্রিনশট ও কোড স্নিপেট রিফ্রেশ করতে ত্রৈমাসিক অডিট শিডিউল করুন।</li>
+            <li lang="en">Automate translation updates when source docs change using repo webhooks.</li>
+            <li class="bangla" lang="bn">সোর্স ডক বদলালে রিপো ওয়েবহুক দিয়ে অনুবাদ আপডেট স্বয়ংক্রিয় করুন।</li>
+          </ul>
+        </section>
+      </article>
+      <a class="back-link" href="../index.html">← Back to all posts</a>
+    </main>
+    <footer>
+      <p lang="en">Crafted for curious technologists. Follow <a href="https://github.com/sheikhcoders">@sheikhcoders</a> for new posts.</p>
+      <p class="bangla" lang="bn">
+        অনুসন্ধিৎসু টেক উত্সাহীদের জন্য নিয়মিত আপডেট। <a href="https://github.com/sheikhcoders">@sheikhcoders</a> অনুসরণ করুন।
+      </p>
+      <p>&copy; <span id="year">2024</span> Sheikh Coders. All rights reserved.</p>
+    </footer>
+    <script>
+      const year = document.getElementById("year");
+      if (year) {
+        year.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/blog/nextjs-github-actions.html
+++ b/blog/nextjs-github-actions.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Deploy Next.js with GitHub Actions | Sheikh Coders Blog</title>
+    <meta
+      name="description"
+      content="Automate Next.js builds with GitHub Actions: caching, tests, deploy hooks, and bilingual safeguards for reliable releases."
+    />
+    <meta
+      name="keywords"
+      content="Next.js GitHub Actions, Next.js CI/CD, deploy hook workflow, Bangla DevOps guide, GitHub Pages Next.js, Vercel deploy automation"
+    />
+    <meta name="author" content="Sheikh Coders" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://sheikhcoders.github.io/blog/nextjs-github-actions.html" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/nextjs-github-actions.html" hreflang="x-default" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/nextjs-github-actions.html" hreflang="en" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/nextjs-github-actions.html#bangla" hreflang="bn" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Deploy Next.js with GitHub Actions" />
+    <meta
+      property="og:description"
+      content="Step-by-step GitHub Actions workflow for building, testing, and deploying Next.js with secrets and rollback tips."
+    />
+    <meta property="og:url" content="https://sheikhcoders.github.io/blog/nextjs-github-actions.html" />
+    <meta property="og:image" content="https://sheikhcoders.github.io/assets/cover.svg" />
+    <meta property="og:site_name" content="Sheikh Coders" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="bn_BD" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Deploy Next.js with GitHub Actions" />
+    <meta
+      name="twitter:description"
+      content="Build, test, and deploy Next.js with GitHub Actions deploy hooks, caching, and bilingual resilience notes."
+    />
+    <meta name="twitter:image" content="https://sheikhcoders.github.io/assets/cover.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Deploy Next.js with GitHub Actions",
+        "inLanguage": ["en", "bn"],
+        "author": {
+          "@type": "Person",
+          "name": "Sheikh Coders"
+        },
+        "datePublished": "2024-06-02",
+        "dateModified": "2024-06-02",
+        "mainEntityOfPage": "https://sheikhcoders.github.io/blog/nextjs-github-actions.html",
+        "image": "https://sheikhcoders.github.io/assets/cover.svg",
+        "publisher": {
+          "@type": "Organization",
+          "name": "Sheikh Coders",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sheikhcoders.github.io/assets/cover.svg"
+          }
+        },
+        "description": "Automated Next.js pipeline using GitHub Actions with caching, tests, deploy hooks, and rollback tips."
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://sheikhcoders.github.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Blog",
+            "item": "https://sheikhcoders.github.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Deploy Next.js with GitHub Actions"
+          }
+        ]
+      }
+    </script>
+  </head>
+  <body class="article-page">
+    <header>
+      <nav>
+        <a class="brand" href="../index.html">Sheikh Coders</a>
+        <a class="subscribe" href="mailto:hello@sheikhcoders.com">Stay in the Loop</a>
+      </nav>
+      <div class="hero">
+        <h1>Deploy Next.js with GitHub Actions</h1>
+        <p lang="en">Automate builds, tests, and deploy hooks so production stays reliable.</p>
+        <p class="bangla" lang="bn">বিল্ড, টেস্ট ও ডিপ্লয় হুক স্বয়ংক্রিয় করে প্রোডাকশনকে নির্ভরযোগ্য রাখুন।</p>
+      </div>
+    </header>
+    <main>
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../index.html">Home</a>
+        <span aria-hidden="true">/</span>
+        <a href="../index.html">Blog</a>
+        <span aria-hidden="true">/</span>
+        <span>Next.js GitHub Actions</span>
+      </nav>
+      <section class="article-hero">
+        <div class="article-meta">
+          <time datetime="2024-06-02">02 Jun 2024</time>
+          <span aria-hidden="true">•</span>
+          <span>6 minute read</span>
+          <span aria-hidden="true">•</span>
+          <span>English &amp; Bangla</span>
+        </div>
+        <p lang="en">
+          GitHub Actions can build, lint, test, and deploy your Next.js project whenever you merge to main. Keep secrets encrypted and ship via
+          Vercel or GitHub Pages without manual steps.
+        </p>
+        <p class="bangla" id="bangla" lang="bn">
+          যখনই মেইন ব্রাঞ্চে মার্জ করবেন, গিটহাব অ্যাকশন্স আপনার নেক্সট.জেএস প্রজেক্ট বিল্ড, লিন্ট, টেস্ট ও ডিপ্লয় করতে পারে। সিক্রেট এনক্রিপ্ট রাখুন এবং ভার্সেল বা গিটহাব পেজেসে স্বয়ংক্রিয়ভাবে প্রকাশ করুন।
+        </p>
+      </section>
+      <aside class="toc" aria-label="Table of contents">
+        <h2>Quick navigation</h2>
+        <ol>
+          <li><a href="#workflow">Workflow overview</a></li>
+          <li><a href="#secrets">Secrets &amp; security</a></li>
+          <li><a href="#resilience">Resilience &amp; rollbacks</a></li>
+        </ol>
+      </aside>
+      <article class="article-body">
+        <section id="workflow">
+          <h2>Workflow overview</h2>
+          <p lang="en">
+            Start with a single job that checks out your repo, sets up Node.js, installs dependencies with caching, runs lint/test commands, and
+            triggers a deploy hook.
+          </p>
+          <p class="bangla" lang="bn">
+            একটি জব দিয়ে শুরু করুন যা রেপো চেকআউট করে, নোড সেটআপ করে, ক্যাশ সহ ডিপেন্ডেন্সি ইনস্টল করে, লিন্ট/টেস্ট চালায় এবং ডিপ্লয় হুক ট্রিগার করে।
+          </p>
+          <pre><code>name: Deploy Next.js
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test -- --watch=false
+      - run: npm run build
+      - name: Trigger Vercel Deploy Hook
+        run: curl -X POST "$VERCEL_DEPLOY_HOOK"</code></pre>
+          <ul>
+            <li lang="en">Swap the deploy hook for <code>actions/upload-pages-artifact</code> and <code>deploy-pages</code> to publish to GitHub Pages.</li>
+            <li class="bangla" lang="bn">গিটহাব পেজেসে প্রকাশ করতে ডিপ্লয় হুকের বদলে <code>actions/upload-pages-artifact</code> ও <code>deploy-pages</code> ব্যবহার করুন।</li>
+          </ul>
+        </section>
+        <section id="secrets">
+          <h2>Secrets &amp; security</h2>
+          <p lang="en">
+            Store deploy hooks, API keys, and environment URLs as encrypted repository secrets. Require reviewers for production environments and
+            lock workflows to specific branches.
+          </p>
+          <p class="bangla" lang="bn">
+            ডিপ্লয় হুক, এপিআই কী ও এনভায়রনমেন্ট ইউআরএল রেপো সিক্রেট হিসেবে এনক্রিপ্ট করে রাখুন। প্রোডাকশন এনভায়রনমেন্টের জন্য রিভিউয়ার আবশ্যক করুন এবং নির্দিষ্ট ব্রাঞ্চে ওয়ার্কফ্লো সীমাবদ্ধ রাখুন।
+          </p>
+          <div class="note-box" lang="en">
+            Rotate secrets quarterly and audit who has access. Pair with OIDC deployments when possible to avoid long-lived tokens.
+          </div>
+          <div class="note-box bangla" lang="bn">
+            প্রতি ত্রৈমাসিকে সিক্রেট রোটেট করুন এবং কারা অ্যাক্সেস পাচ্ছে তা অডিট করুন। সম্ভব হলে OIDC ডিপ্লয় ব্যবহার করুন যাতে দীর্ঘস্থায়ী টোকেনের প্রয়োজন না হয়।
+          </div>
+          <ul>
+            <li lang="en">Use <code>actions/cache</code> with a hash of <code>package-lock.json</code> for faster installs.</li>
+            <li class="bangla" lang="bn"><code>package-lock.json</code> এর হ্যাশ দিয়ে <code>actions/cache</code> ব্যবহার করুন যেন ইনস্টল দ্রুত হয়।</li>
+            <li lang="en">Add <code>concurrency</code> groups to auto-cancel outdated deploy runs.</li>
+            <li class="bangla" lang="bn">পুরনো ডিপ্লয় রান বাতিল করতে <code>concurrency</code> গ্রুপ সেট করুন।</li>
+          </ul>
+        </section>
+        <section id="resilience">
+          <h2>Resilience &amp; rollbacks</h2>
+          <p lang="en">
+            Wire a <code>workflow_run</code> trigger that listens for failed deploys and reverts to the previous stable build. Send Slack or email
+            alerts so teams can respond quickly.
+          </p>
+          <p class="bangla" lang="bn">
+            ডিপ্লয় ব্যর্থ হলে <code>workflow_run</code> ট্রিগার দিয়ে আগের স্থিতিশীল বিল্ডে রোলব্যাক করুন। স্ল্যাক বা ইমেইল অ্যালার্ট পাঠান যাতে টিম দ্রুত প্রতিক্রিয়া জানাতে পারে।
+          </p>
+          <ul>
+            <li lang="en">Run smoke tests against preview URLs before promoting to production.</li>
+            <li class="bangla" lang="bn">প্রোডাকশনে পাঠানোর আগে প্রিভিউ ইউআরএলে স্মোক টেস্ট চালান।</li>
+            <li lang="en">Keep an incident playbook describing rollback steps and contact points.</li>
+            <li class="bangla" lang="bn">রোলব্যাক ধাপ ও যোগাযোগ তথ্যসহ একটি ইনসিডেন্ট প্লেবুক রাখুন।</li>
+          </ul>
+        </section>
+      </article>
+      <a class="back-link" href="../index.html">← Back to all posts</a>
+    </main>
+    <footer>
+      <p lang="en">Crafted for curious technologists. Follow <a href="https://github.com/sheikhcoders">@sheikhcoders</a> for new posts.</p>
+      <p class="bangla" lang="bn">
+        অনুসন্ধিৎসু টেক উত্সাহীদের জন্য নিয়মিত আপডেট। <a href="https://github.com/sheikhcoders">@sheikhcoders</a> অনুসরণ করুন।
+      </p>
+      <p>&copy; <span id="year">2024</span> Sheikh Coders. All rights reserved.</p>
+    </footer>
+    <script>
+      const year = document.getElementById("year");
+      if (year) {
+        year.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/blog/nextjs-performance.html
+++ b/blog/nextjs-performance.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Starter Guide to Next.js Performance | Sheikh Coders Blog</title>
+    <meta
+      name="description"
+      content="Tune a new Next.js project with app router best practices, font optimisation, Core Web Vitals measurement, and bilingual launch checklists."
+    />
+    <meta
+      name="keywords"
+      content="Next.js performance, Core Web Vitals, next/font optimization, Lighthouse CI, Bangla Next.js guide, app router tips"
+    />
+    <meta name="author" content="Sheikh Coders" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://sheikhcoders.github.io/blog/nextjs-performance.html" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/nextjs-performance.html" hreflang="x-default" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/nextjs-performance.html" hreflang="en" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/nextjs-performance.html#bangla" hreflang="bn" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Starter Guide to Next.js Performance" />
+    <meta
+      property="og:description"
+      content="Bilingual checklist for fast Next.js launches with metadata APIs, next/font, and measurable Core Web Vitals."
+    />
+    <meta property="og:url" content="https://sheikhcoders.github.io/blog/nextjs-performance.html" />
+    <meta property="og:image" content="https://sheikhcoders.github.io/assets/cover.svg" />
+    <meta property="og:site_name" content="Sheikh Coders" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="bn_BD" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Starter Guide to Next.js Performance" />
+    <meta
+      name="twitter:description"
+      content="Speed up your Next.js app with bilingual tips on code splitting, fonts, image optimisation, and performance budgets."
+    />
+    <meta name="twitter:image" content="https://sheikhcoders.github.io/assets/cover.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Starter Guide to Next.js Performance",
+        "inLanguage": ["en", "bn"],
+        "author": {
+          "@type": "Person",
+          "name": "Sheikh Coders"
+        },
+        "datePublished": "2024-04-28",
+        "dateModified": "2024-04-28",
+        "mainEntityOfPage": "https://sheikhcoders.github.io/blog/nextjs-performance.html",
+        "image": "https://sheikhcoders.github.io/assets/cover.svg",
+        "publisher": {
+          "@type": "Organization",
+          "name": "Sheikh Coders",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sheikhcoders.github.io/assets/cover.svg"
+          }
+        },
+        "description": "Quick performance checklist for Next.js including metadata APIs, fonts, and Core Web Vitals."
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://sheikhcoders.github.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Blog",
+            "item": "https://sheikhcoders.github.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Starter Guide to Next.js Performance"
+          }
+        ]
+      }
+    </script>
+  </head>
+  <body class="article-page">
+    <header>
+      <nav>
+        <a class="brand" href="../index.html">Sheikh Coders</a>
+        <a class="subscribe" href="mailto:hello@sheikhcoders.com">Stay in the Loop</a>
+      </nav>
+      <div class="hero">
+        <h1>Starter Guide to Next.js Performance</h1>
+        <p lang="en">Optimise your first deploy with modern routing, fonts, and measurement rituals.</p>
+        <p class="bangla" lang="bn">আধুনিক রাউটিং, ফন্ট ও মাপজোকের রুটিন দিয়ে প্রথম নেক্সট.জেএস ডিপ্লয়কে অপ্টিমাইজ করুন।</p>
+      </div>
+    </header>
+    <main>
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../index.html">Home</a>
+        <span aria-hidden="true">/</span>
+        <a href="../index.html">Blog</a>
+        <span aria-hidden="true">/</span>
+        <span>Next.js Performance</span>
+      </nav>
+      <section class="article-hero">
+        <div class="article-meta">
+          <time datetime="2024-04-28">28 Apr 2024</time>
+          <span aria-hidden="true">•</span>
+          <span>5 minute read</span>
+          <span aria-hidden="true">•</span>
+          <span>English &amp; Bangla</span>
+        </div>
+        <p lang="en">
+          The Next.js app router ships opinionated defaults, but a few extra guardrails ensure lightning-fast loads and resilient SEO signals on
+          launch day.
+        </p>
+        <p class="bangla" id="bangla" lang="bn">
+          Next.js এর app router কিছু অপ্টিমাইজেশন নিয়ে আসে, তবে কয়েকটি অতিরিক্ত ধাপ নিলে লঞ্চের সময় গতি ও এসইও সুরক্ষিত থাকে।
+        </p>
+      </section>
+      <aside class="toc" aria-label="Table of contents">
+        <h2>Quick navigation</h2>
+        <ol>
+          <li><a href="#app-router">App router fundamentals</a></li>
+          <li><a href="#measure">Measure Core Web Vitals</a></li>
+          <li><a href="#ship">Ship with budgets</a></li>
+        </ol>
+      </aside>
+      <article class="article-body">
+        <section id="app-router">
+          <h2>App router fundamentals</h2>
+          <p lang="en">
+            Lean into the <code>app/</code> directory for automatic code-splitting, streaming layouts, and the new metadata APIs. Wrap fonts with
+            <code>next/font</code> to inline critical subsets without blocking render.
+          </p>
+          <p class="bangla" lang="bn">
+            স্বয়ংক্রিয় কোড স্প্লিটিং, স্ট্রিমিং লেআউট ও মেটাডাটা এপিআই পেতে <code>app/</code> ডিরেক্টরি ব্যবহার করুন। রেন্ডার ব্লক ছাড়া ক্রিটিকাল ফন্ট ইনলাইন করতে
+            <code>next/font</code> ব্যবহার করুন।
+          </p>
+          <ul>
+            <li lang="en">Enable <code>experimental.optimizePackageImports</code> to trim unused library code before bundling.</li>
+            <li class="bangla" lang="bn">বান্ডল তৈরির আগে অব্যবহৃত লাইব্রেরি কোড কমাতে <code>experimental.optimizePackageImports</code> চালু করুন।</li>
+            <li lang="en">Leverage the <code>dynamic = "force-static"</code> export for marketing pages that rarely change.</li>
+            <li class="bangla" lang="bn">কম পরিবর্তনশীল মার্কেটিং পেইজের জন্য <code>dynamic = "force-static"</code> ব্যবহার করুন।</li>
+          </ul>
+        </section>
+        <section id="measure">
+          <h2>Measure Core Web Vitals</h2>
+          <p lang="en">
+            Hook into <code>reportWebVitals</code> to stream vital metrics into your analytics provider. Pair field data with
+            lab runs from Lighthouse to catch regressions before shipping.
+          </p>
+          <p class="bangla" lang="bn">
+            <code>reportWebVitals</code> ব্যবহার করে গুরুত্বপূর্ণ মেট্রিক আপনার অ্যানালিটিক্সে পাঠান। শিপ করার আগে লাইটহাউসের ল্যাব ডেটার সাথে ফিল্ড ডেটা মিলিয়ে রিগ্রেশন ধরুন।
+          </p>
+          <pre><code class="language-js">export function reportWebVitals(metric) {
+  if (metric.name === "LCP" || metric.name === "FID") {
+    fetch("/api/vitals", {
+      method: "POST",
+      body: JSON.stringify(metric),
+    });
+  }
+}</code></pre>
+          <div class="note-box" lang="en">
+            Set baseline goals: LCP &lt; 2.5&nbsp;s, CLS &lt; 0.1, TBT &lt; 200&nbsp;ms. Track them per route, not just globally.
+          </div>
+          <div class="note-box bangla" lang="bn">
+            বেসলাইন লক্ষ্য নির্ধারণ করুন: LCP &lt; ২.৫ সেকেন্ড, CLS &lt; ০.১, TBT &lt; ২০০ মিলিসেকেন্ড। প্রতিটি রুট অনুযায়ী অগ্রগতি দেখুন।
+          </div>
+        </section>
+        <section id="ship">
+          <h2>Ship with budgets</h2>
+          <p lang="en">
+            Automate Lighthouse CI in your pipeline with thresholds that fail builds when metrics regress. Include mobile-first
+            screenshots to validate layout shifts and ensure translation fallback paths stay intact.
+          </p>
+          <p class="bangla" lang="bn">
+            মেট্রিক খারাপ হলে বিল্ড ব্যর্থ করার জন্য পাইপলাইনে লাইটহাউস সিআই স্বয়ংক্রিয় করুন। মোবাইল স্ক্রিনশট যুক্ত করুন যাতে লেআউট শিফট ও অনুবাদ ফallback দেখা যায়।
+          </p>
+          <ul>
+            <li lang="en">Test image-heavy routes with <code>next/image</code> placeholders to protect CLS.</li>
+            <li class="bangla" lang="bn">CLS নিয়ন্ত্রণে রাখতে ইমেজ-নির্ভর রুটে <code>next/image</code> প্লেসহোল্ডার ব্যবহার করুন।</li>
+            <li lang="en">Cache fonts and data fetches with <code>revalidate</code> hints tuned to content freshness.</li>
+            <li class="bangla" lang="bn">কনটেন্টের সতেজতার সাথে মিল রেখে <code>revalidate</code> হিন্ট দিয়ে ফন্ট ও ডেটা ক্যাশ করুন।</li>
+          </ul>
+        </section>
+      </article>
+      <a class="back-link" href="../index.html">← Back to all posts</a>
+    </main>
+    <footer>
+      <p lang="en">Crafted for curious technologists. Follow <a href="https://github.com/sheikhcoders">@sheikhcoders</a> for new posts.</p>
+      <p class="bangla" lang="bn">
+        অনুসন্ধিৎসু টেক উত্সাহীদের জন্য নিয়মিত আপডেট। <a href="https://github.com/sheikhcoders">@sheikhcoders</a> অনুসরণ করুন।
+      </p>
+      <p>&copy; <span id="year">2024</span> Sheikh Coders. All rights reserved.</p>
+    </footer>
+    <script>
+      const year = document.getElementById("year");
+      if (year) {
+        year.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/blog/portfolio-landing.html
+++ b/blog/portfolio-landing.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Build a Clean Portfolio Landing Page | Sheikh Coders Blog</title>
+    <meta
+      name="description"
+      content="Design a minimalist, bilingual portfolio landing page with semantic HTML, mobile-first spacing, and SEO metadata that recruiters can skim in seconds."
+    />
+    <meta
+      name="keywords"
+      content="portfolio landing page, responsive portfolio, semantic HTML portfolio, Bangla portfolio guide, mobile-first design, SEO portfolio checklist"
+    />
+    <meta name="author" content="Sheikh Coders" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://sheikhcoders.github.io/blog/portfolio-landing.html" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/portfolio-landing.html" hreflang="x-default" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/portfolio-landing.html" hreflang="en" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/portfolio-landing.html#bangla" hreflang="bn" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Build a Clean Portfolio Landing Page" />
+    <meta
+      property="og:description"
+      content="Step-by-step guide to launch a recruiter-friendly portfolio page with bilingual summaries, responsive typography, and complete metadata."
+    />
+    <meta property="og:url" content="https://sheikhcoders.github.io/blog/portfolio-landing.html" />
+    <meta property="og:image" content="https://sheikhcoders.github.io/assets/cover.svg" />
+    <meta property="og:site_name" content="Sheikh Coders" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="bn_BD" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Build a Clean Portfolio Landing Page" />
+    <meta
+      name="twitter:description"
+      content="Make your next portfolio irresistible with semantic HTML, responsive typography, and bilingual CTAs."
+    />
+    <meta name="twitter:image" content="https://sheikhcoders.github.io/assets/cover.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Build a Clean Portfolio Landing Page",
+        "inLanguage": ["en", "bn"],
+        "author": {
+          "@type": "Person",
+          "name": "Sheikh Coders"
+        },
+        "datePublished": "2024-05-10",
+        "dateModified": "2024-05-10",
+        "mainEntityOfPage": "https://sheikhcoders.github.io/blog/portfolio-landing.html",
+        "image": "https://sheikhcoders.github.io/assets/cover.svg",
+        "publisher": {
+          "@type": "Organization",
+          "name": "Sheikh Coders",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sheikhcoders.github.io/assets/cover.svg"
+          }
+        },
+        "description": "Design a minimalist, bilingual portfolio landing page with semantic HTML, mobile-first spacing, and SEO metadata."
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://sheikhcoders.github.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Blog",
+            "item": "https://sheikhcoders.github.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Build a Clean Portfolio Landing Page"
+          }
+        ]
+      }
+    </script>
+  </head>
+  <body class="article-page">
+    <header>
+      <nav>
+        <a class="brand" href="../index.html">Sheikh Coders</a>
+        <a class="subscribe" href="mailto:hello@sheikhcoders.com">Stay in the Loop</a>
+      </nav>
+      <div class="hero">
+        <h1>Build a Clean Portfolio Landing Page</h1>
+        <p lang="en">A recruiter-ready template with copy decks, mobile spacing, and metadata baked in.</p>
+        <p class="bangla" lang="bn">রেস্পন্সিভ স্পেসিং ও মেটাডাটা সহ একটি নিয়োগকারী-বান্ধব পোর্টফোলিও টেমপ্লেট।</p>
+      </div>
+    </header>
+    <main>
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../index.html">Home</a>
+        <span aria-hidden="true">/</span>
+        <a href="../index.html">Blog</a>
+        <span aria-hidden="true">/</span>
+        <span>Portfolio Landing Page</span>
+      </nav>
+      <section class="article-hero">
+        <div class="article-meta">
+          <time datetime="2024-05-10">10 May 2024</time>
+          <span aria-hidden="true">•</span>
+          <span>5 minute read</span>
+          <span aria-hidden="true">•</span>
+          <span>English &amp; Bangla</span>
+        </div>
+        <p lang="en">
+          Ship a single-page portfolio that feels intentional on every screen, loads in less than a second, and tells a clear
+          story about your craft.
+        </p>
+        <p class="bangla" id="bangla" lang="bn">
+          যেকোনো স্ক্রিনে সমান কার্যকর, দ্রুত লোড হওয়া এবং আপনার কাজের গল্প পরিষ্কারভাবে তুলে ধরে এমন এক-পেইজের পোর্টফোলিও তৈরি করুন।
+        </p>
+      </section>
+      <aside class="toc" aria-label="Table of contents">
+        <h2>Quick navigation</h2>
+        <ol>
+          <li><a href="#semantic-structure">Semantic layout foundations</a></li>
+          <li><a href="#visual-rhythm">Visual rhythm &amp; typography</a></li>
+          <li><a href="#conversion-seo">Conversion &amp; SEO checklist</a></li>
+        </ol>
+      </aside>
+      <article class="article-body">
+        <section id="semantic-structure">
+          <h2>Semantic layout foundations</h2>
+          <p lang="en">
+            Start with a clear <code>&lt;header&gt;</code>, <code>&lt;main&gt;</code>, and <code>&lt;footer&gt;</code> hierarchy so screen readers and
+            crawlers understand relationships instantly. Use descriptive <code>&lt;section&gt;</code> labels such as
+            <code>aria-label="Hero introduction"</code> and <code>aria-labelledby</code> attributes for highlight cards.
+          </p>
+          <p class="bangla" lang="bn">
+            স্ক্রিন রিডার ও সার্চ ইঞ্জিন যেন দ্রুত কাঠামো বুঝতে পারে সেজন্য <code>&lt;header&gt;</code>, <code>&lt;main&gt;</code>,
+            <code>&lt;footer&gt;</code> এর মত সেমান্টিক হায়ারার্কি দিয়ে শুরু করুন। <code>aria-label</code> ও
+            <code>aria-labelledby</code> দিয়ে প্রতিটি সেকশন স্পষ্টভাবে বর্ণনা করুন।
+          </p>
+          <ul>
+            <li lang="en">Group hero copy inside a <code>&lt;div role="group"&gt;</code> to keep headings and CTAs clustered.</li>
+            <li class="bangla" lang="bn">শিরোনাম ও সিটিএ একত্রে রাখতে <code>&lt;div role="group"&gt;</code> ব্যবহার করুন।</li>
+            <li lang="en">Expose contact and social links in both the header and footer for quick recruiter access.</li>
+            <li class="bangla" lang="bn">রিক্রুটার যেন দ্রুত যোগাযোগ করতে পারে সে জন্য হেডার ও ফুটারে যোগাযোগ লিঙ্ক দিন।</li>
+          </ul>
+        </section>
+        <section id="visual-rhythm">
+          <h2>Visual rhythm &amp; typography</h2>
+          <p lang="en">
+            Use <code>clamp()</code> to scale typography from 320&nbsp;px screens to desktop monitors. Pair a bold display type with a calmer
+            supporting font weight to keep breathing room around testimonials and project cards.
+          </p>
+          <p class="bangla" lang="bn">
+            <code>clamp()</code> দিয়ে টাইপোগ্রাফি স্কেল করলে ৩২০ পিক্সেল মোবাইল থেকে ডেস্কটপ পর্যন্ত পড়তে সহজ থাকে। প্রজেক্ট কার্ড ও টেস্টিমোনিয়ালকে
+            ভারসাম্য দিতে শিরোনামে বোল্ড ও বডিতে হালকা ফন্ট ওজন ব্যবহার করুন।
+          </p>
+          <div class="note-box" lang="en">
+            Audit the layout at 320&nbsp;px, 768&nbsp;px, and 1280&nbsp;px. Adjust gap utilities before touching font sizes—spacing shifts deliver
+            faster wins.
+          </div>
+          <div class="note-box bangla" lang="bn">
+            ৩২০, ৭৬৮ ও ১২৮০ পিক্সেলে লেআউট যাচাই করুন। ফন্ট সাইজ বদলানোর আগে গ্যাপ ইউটিলিটি সামঞ্জস্য করলে দ্রুত ফল পাওয়া যায়।
+          </div>
+        </section>
+        <section id="conversion-seo">
+          <h2>Conversion &amp; SEO checklist</h2>
+          <p lang="en">
+            Map Open Graph, Twitter, and JSON-LD metadata directly to the hero copy so sharing cards mirror the promise on the page. Track CTA
+            clicks with <code>data-analytics</code> attributes and keep your contact form behind a bot-protected endpoint.
+          </p>
+          <p class="bangla" lang="bn">
+            হিরো সেকশনের কপির সাথে মিল রেখে ওপেন গ্রাফ, টুইটার ও JSON-LD মেটাডাটা সেট করুন যাতে শেয়ারের সময় একই বার্তা দেখা যায়। CTA-তে
+            <code>data-analytics</code> অ্যাট্রিবিউট দিয়ে ক্লিক ট্র্যাক করুন এবং বট সুরক্ষিত এন্ডপয়েন্টের মাধ্যমে কন্টাক্ট ফর্ম জমা নিন।
+          </p>
+          <ul>
+            <li lang="en">Add <code>rel="me"</code> to social profiles to confirm ownership in modern search experiences.</li>
+            <li class="bangla" lang="bn">সোশ্যাল প্রোফাইলে <code>rel="me"</code> ব্যবহার করলে সার্চ অভিজ্ঞতায় মালিকানা যাচাই সহজ হয়।</li>
+            <li lang="en">Keep the page under 100&nbsp;KB by compressing hero art with <code>&lt;picture&gt;</code> and <code>loading="lazy"</code>.</li>
+            <li class="bangla" lang="bn">হিরো ইমেজকে <code>&lt;picture&gt;</code> ও <code>loading="lazy"</code> দিয়ে ১০০ কিলোবাইটের নিচে রাখুন।</li>
+            <li lang="en">Publish a <code>sitemap.xml</code> entry focused on your primary case studies to reinforce topical authority.</li>
+            <li class="bangla" lang="bn">টপিক্যাল অথরিটি বাড়াতে প্রধান কেস স্টাডি গুলোকে <code>sitemap.xml</code>-এ আলাদা এন্ট্রি দিন।</li>
+          </ul>
+        </section>
+      </article>
+      <a class="back-link" href="../index.html">← Back to all posts</a>
+    </main>
+    <footer>
+      <p lang="en">Crafted for curious technologists. Follow <a href="https://github.com/sheikhcoders">@sheikhcoders</a> for new posts.</p>
+      <p class="bangla" lang="bn">
+        অনুসন্ধিৎসু টেক উত্সাহীদের জন্য নিয়মিত আপডেট। <a href="https://github.com/sheikhcoders">@sheikhcoders</a> অনুসরণ করুন।
+      </p>
+      <p>&copy; <span id="year">2024</span> Sheikh Coders. All rights reserved.</p>
+    </footer>
+    <script>
+      const year = document.getElementById("year");
+      if (year) {
+        year.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/blog/query-string-seo.html
+++ b/blog/query-string-seo.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mastering URL Query Strings for Focused SEO | Sheikh Coders Blog</title>
+    <meta
+      name="description"
+      content="Learn how to structure, track, and govern URL query strings so every campaign stays crawlable, bilingual, and analytics-ready."
+    />
+    <meta
+      name="keywords"
+      content="URL query string SEO, query parameters governance, Bangla SEO tips, analytics tagging, canonical URLs, URLSearchParams"
+    />
+    <meta name="author" content="Sheikh Coders" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://sheikhcoders.github.io/blog/query-string-seo.html" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/query-string-seo.html" hreflang="x-default" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/query-string-seo.html" hreflang="en" />
+    <link rel="alternate" href="https://sheikhcoders.github.io/blog/query-string-seo.html#bangla" hreflang="bn" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Mastering URL Query Strings for Focused SEO" />
+    <meta
+      property="og:description"
+      content="Bilingual strategies for readable query parameters, canonical hygiene, and analytics handoffs."
+    />
+    <meta property="og:url" content="https://sheikhcoders.github.io/blog/query-string-seo.html" />
+    <meta property="og:image" content="https://sheikhcoders.github.io/assets/cover.svg" />
+    <meta property="og:site_name" content="Sheikh Coders" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="bn_BD" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Mastering URL Query Strings for Focused SEO" />
+    <meta
+      name="twitter:description"
+      content="Keep campaigns tidy with readable parameters, canonical logic, and analytics governance tips in English and Bangla."
+    />
+    <meta name="twitter:image" content="https://sheikhcoders.github.io/assets/cover.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "Mastering URL Query Strings for Focused SEO",
+        "inLanguage": ["en", "bn"],
+        "author": {
+          "@type": "Person",
+          "name": "Sheikh Coders"
+        },
+        "datePublished": "2024-05-18",
+        "dateModified": "2024-05-18",
+        "mainEntityOfPage": "https://sheikhcoders.github.io/blog/query-string-seo.html",
+        "image": "https://sheikhcoders.github.io/assets/cover.svg",
+        "publisher": {
+          "@type": "Organization",
+          "name": "Sheikh Coders",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://sheikhcoders.github.io/assets/cover.svg"
+          }
+        },
+        "description": "Readable, governable query strings with canonical and analytics workflows."
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://sheikhcoders.github.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Blog",
+            "item": "https://sheikhcoders.github.io/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Mastering URL Query Strings for Focused SEO"
+          }
+        ]
+      }
+    </script>
+  </head>
+  <body class="article-page">
+    <header>
+      <nav>
+        <a class="brand" href="../index.html">Sheikh Coders</a>
+        <a class="subscribe" href="mailto:hello@sheikhcoders.com">Stay in the Loop</a>
+      </nav>
+      <div class="hero">
+        <h1>Mastering URL Query Strings for Focused SEO</h1>
+        <p lang="en">Govern campaign parameters without losing crawl budget or analytics clarity.</p>
+        <p class="bangla" lang="bn">কুয়েরি প্যারামিটার ব্যবস্থাপনা করে সার্চ পারফরমেন্স ও অ্যানালিটিক্সকে সঠিক রাখুন।</p>
+      </div>
+    </header>
+    <main>
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="../index.html">Home</a>
+        <span aria-hidden="true">/</span>
+        <a href="../index.html">Blog</a>
+        <span aria-hidden="true">/</span>
+        <span>Query String SEO</span>
+      </nav>
+      <section class="article-hero">
+        <div class="article-meta">
+          <time datetime="2024-05-18">18 May 2024</time>
+          <span aria-hidden="true">•</span>
+          <span>6 minute read</span>
+          <span aria-hidden="true">•</span>
+          <span>English &amp; Bangla</span>
+        </div>
+        <p lang="en">
+          A URL query string starts after the <code>?</code> and carries key-value pairs that personalise journeys, filter
+          catalogues, or tag campaigns. Manage them intentionally to avoid duplicate crawling and inconsistent reports.
+        </p>
+        <p class="bangla" id="bangla" lang="bn">
+          <code>?</code> চিহ্নের পরে থাকা কুয়েরি স্ট্রিং ব্যবহারকারীকে ব্যক্তিগত অভিজ্ঞতা দেয়, ফিল্টারিং করে এবং ক্যাম্পেইন ট্র্যাক করে। সচেতনভাবে
+          ব্যবস্থাপনা না করলে ডুপ্লিকেট ক্রলিং ও বিশৃঙ্খল রিপোর্ট তৈরি হয়।
+        </p>
+      </section>
+      <aside class="toc" aria-label="Table of contents">
+        <h2>Quick navigation</h2>
+        <ol>
+          <li><a href="#readable-parameters">Readable parameter design</a></li>
+          <li><a href="#governance">Governance &amp; analytics</a></li>
+          <li><a href="#implementation">Implementation blueprint</a></li>
+        </ol>
+      </aside>
+      <article class="article-body">
+        <section id="readable-parameters">
+          <h2>Readable parameter design</h2>
+          <p lang="en">
+            Keep keys descriptive (<code>category=css</code> over <code>cat=1</code>) so segmentation is transparent. Align the
+            language of your parameter values with keyword research—if your audience searches “tutorials”, use
+            <code>type=tutorial</code> not <code>type=guide</code>.
+          </p>
+          <p class="bangla" lang="bn">
+            কী নামগুলো বোধগম্য রাখুন (<code>category=css</code> এর মতো) যেন সেগমেন্টেশন সহজ বোঝা যায়। শ্রোতারা যেসব কীওয়ার্ড সার্চ করে সেগুলোর সাথে মিলিয়ে
+            ভ্যালু দিন—যদি সবাই “টিউটোরিয়াল” খোঁজে তবে <code>type=tutorial</code> ব্যবহার করুন।
+          </p>
+          <ul>
+            <li lang="en">Document every approved key/value pair in your product or campaign playbook.</li>
+            <li class="bangla" lang="bn">প্রোডাক্ট বা ক্যাম্পেইন প্লেবুকে অনুমোদিত প্রতিটি কী/ভ্যালু নথিভুক্ত করুন।</li>
+            <li lang="en">Reserve <code>ref</code> or <code>source</code> parameters for top-of-funnel awareness tracking.</li>
+            <li class="bangla" lang="bn">শীর্ষ স্তরের সচেতনতা ট্র্যাক করতে <code>ref</code> বা <code>source</code> প্যারামিটার আলাদা রাখুন।</li>
+          </ul>
+        </section>
+        <section id="governance">
+          <h2>Governance &amp; analytics</h2>
+          <p lang="en">
+            Define how search engines should treat parameters inside Google Search Console. Mark filters that don’t change content as “No” for
+            crawling while allowing campaign tags to remain crawlable. Pair each parameter group with a canonical root URL.
+          </p>
+          <p class="bangla" lang="bn">
+            গুগল সার্চ কনসোলে প্যারামিটারের আচরণ নির্ধারণ করুন। কন্টেন্ট না বদলানো ফিল্টারগুলোকে “No” হিসাবে সেট করুন এবং ক্যাম্পেইন ট্যাগগুলোকে
+            ক্রলযোগ্য রাখুন। প্রতিটি প্যারামিটার গ্রুপের জন্য ক্যানোনিকাল মূল ইউআরএল নির্ধারণ করুন।
+          </p>
+          <div class="note-box" lang="en">
+            Establish a quarterly review: export parameter combinations, sort by conversions, and deprecate low-impact URLs to reclaim crawl
+            budget.
+          </div>
+          <div class="note-box bangla" lang="bn">
+            ত্রৈমাসিক পর্যালোচনা চালান: প্যারামিটার কম্বিনেশন এক্সপোর্ট করে কনভার্সন অনুযায়ী সাজান এবং কম ফলপ্রসূ ইউআরএল অপসারণ করুন।
+          </div>
+          <ul>
+            <li lang="en">Reject unknown keys server-side to prevent cache poisoning or spammed analytics.</li>
+            <li class="bangla" lang="bn">সার্ভার-সাইডে অপরিচিত কী বাতিল করে ক্যাশ পয়জনিং ও স্প্যামড অ্যানালিটিক্স রোধ করুন।</li>
+            <li lang="en">Tag analytics events with the cleaned parameter values for consistent dashboards.</li>
+            <li class="bangla" lang="bn">ক্লিন করা প্যারামিটার ভ্যালু দিয়ে অ্যানালিটিক্স ইভেন্ট ট্যাগ করুন যেন রিপোর্ট এক থাকে।</li>
+          </ul>
+        </section>
+        <section id="implementation">
+          <h2>Implementation blueprint</h2>
+          <p lang="en">
+            Modern browsers ship <code>URLSearchParams</code>, making it easy to parse and validate keys. Provide fallbacks for
+            missing values to maintain predictable UI states.
+          </p>
+          <p class="bangla" lang="bn">
+            আধুনিক ব্রাউজারে <code>URLSearchParams</code> থাকায় প্যারামিটার পড়া ও যাচাই করা সহজ। অনুপস্থিত ভ্যালুর জন্য ডিফল্ট মান দিন যাতে UI স্থিতিশীল থাকে।
+          </p>
+          <pre><code class="language-js">const params = new URLSearchParams(window.location.search);
+const topic = params.get("topic") || "all";
+const isCampaign = params.has("utm_campaign");</code></pre>
+          <ul>
+            <li lang="en">Sync parameter updates with history state changes so analytics and UI remain aligned.</li>
+            <li class="bangla" lang="bn">হিস্ট্রি স্টেট পরিবর্তনের সাথে প্যারামিটার আপডেট মিলিয়ে নিন যাতে UI ও অ্যানালিটিক্স সামঞ্জস্য থাকে।</li>
+            <li lang="en">Surface the active filters in plain text for accessibility and better on-page SEO.</li>
+            <li class="bangla" lang="bn">অ্যাক্সেসিবিলিটি ও অন-পেজ এসইও বাড়াতে সক্রিয় ফিল্টার সরাসরি টেক্সটে দেখান।</li>
+          </ul>
+        </section>
+      </article>
+      <a class="back-link" href="../index.html">← Back to all posts</a>
+    </main>
+    <footer>
+      <p lang="en">Crafted for curious technologists. Follow <a href="https://github.com/sheikhcoders">@sheikhcoders</a> for new posts.</p>
+      <p class="bangla" lang="bn">
+        অনুসন্ধিৎসু টেক উত্সাহীদের জন্য নিয়মিত আপডেট। <a href="https://github.com/sheikhcoders">@sheikhcoders</a> অনুসরণ করুন।
+      </p>
+      <p>&copy; <span id="year">2024</span> Sheikh Coders. All rights reserved.</p>
+    </footer>
+    <script>
+      const year = document.getElementById("year");
+      if (year) {
+        year.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -43,266 +43,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
       rel="stylesheet"
     />
-    <style>
-      :root {
-        color-scheme: light dark;
-        --background: #f9fafb;
-        --foreground: #111827;
-        --accent: #111827;
-        --accent-foreground: #f9fafb;
-        --muted: #6b7280;
-        --card: #ffffff;
-        --card-border: rgba(17, 24, 39, 0.08);
-        --radius: 18px;
-        font-size: 16px;
-      }
-
-      * {
-        box-sizing: border-box;
-      }
-
-      body {
-        margin: 0;
-        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-          sans-serif;
-        background: var(--background);
-        color: var(--foreground);
-        line-height: 1.6;
-      }
-
-      a {
-        color: inherit;
-      }
-
-      header {
-        padding: clamp(2.5rem, 6vw, 4rem) clamp(1rem, 6vw, 5rem) clamp(1.5rem, 5vw, 3rem);
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-      }
-
-      header nav {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-between;
-        align-items: center;
-        gap: 0.75rem;
-      }
-
-      .brand {
-        font-weight: 700;
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
-        font-size: 0.875rem;
-      }
-
-      .subscribe {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.6rem;
-        padding: 0.55rem 1.1rem;
-        border-radius: 999px;
-        background: var(--accent);
-        color: var(--accent-foreground);
-        font-weight: 600;
-        text-decoration: none;
-        transition: transform 150ms ease, box-shadow 150ms ease;
-      }
-
-      .subscribe:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 12px 24px rgba(17, 24, 39, 0.14);
-      }
-
-      .hero {
-        display: grid;
-        gap: 0.75rem;
-        max-width: 780px;
-      }
-
-      .hero h1 {
-        margin: 0;
-        font-size: clamp(2.4rem, 6vw, 3.2rem);
-        line-height: 1.15;
-        letter-spacing: -0.015em;
-      }
-
-      .hero p {
-        margin: 0;
-        color: var(--muted);
-        font-size: clamp(1rem, 2.4vw, 1.15rem);
-      }
-
-      main {
-        padding: 0 clamp(1rem, 6vw, 5rem) clamp(4rem, 10vw, 6rem);
-      }
-
-      .grid {
-        display: grid;
-        gap: 1.75rem;
-        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      }
-
-      article {
-        background: var(--card);
-        border-radius: var(--radius);
-        border: 1px solid var(--card-border);
-        padding: 1.75rem;
-        display: grid;
-        gap: 0.75rem;
-        transition: transform 180ms ease, box-shadow 180ms ease;
-        scroll-margin-top: 5rem;
-      }
-
-      article:hover {
-        transform: translateY(-4px);
-        box-shadow: 0 22px 42px rgba(15, 23, 42, 0.12);
-      }
-
-      article h2 {
-        margin: 0;
-        font-size: 1.35rem;
-      }
-
-      article time {
-        font-size: 0.85rem;
-        text-transform: uppercase;
-        letter-spacing: 0.06em;
-        color: var(--muted);
-      }
-
-      article p {
-        margin: 0;
-        color: var(--muted);
-      }
-
-      .read-more {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.35rem;
-        font-weight: 600;
-        color: var(--accent);
-        text-decoration: none;
-        font-size: 0.95rem;
-      }
-
-      .read-more svg {
-        width: 1rem;
-        height: 1rem;
-        transition: transform 150ms ease;
-      }
-
-      .read-more:hover svg {
-        transform: translateX(2px);
-      }
-
-      .full-posts {
-        margin-top: clamp(3rem, 9vw, 5rem);
-        display: grid;
-        gap: clamp(2rem, 6vw, 3rem);
-      }
-
-      .full-post {
-        background: var(--card);
-        border-radius: var(--radius);
-        border: 1px solid var(--card-border);
-        padding: clamp(1.5rem, 5vw, 2.5rem);
-        display: grid;
-        gap: 1.2rem;
-      }
-
-      .full-post h3 {
-        margin: 0;
-        font-size: clamp(1.5rem, 4vw, 1.85rem);
-      }
-
-      .full-post section {
-        display: grid;
-        gap: 0.75rem;
-      }
-
-      .full-post code {
-        background: rgba(17, 24, 39, 0.08);
-        border-radius: 6px;
-        padding: 0.2rem 0.4rem;
-        font-family: "Fira Code", "Geist Mono", monospace;
-      }
-
-      .full-post pre {
-        overflow-x: auto;
-        margin: 0;
-        background: rgba(17, 24, 39, 0.08);
-        padding: 1rem;
-        border-radius: 10px;
-        font-size: 0.95rem;
-      }
-
-      .full-post ul,
-      .full-post ol {
-        margin: 0;
-        padding-left: 1.2rem;
-        display: grid;
-        gap: 0.5rem;
-      }
-
-      .bangla {
-        font-weight: 500;
-        color: var(--foreground);
-      }
-
-      footer {
-        padding: clamp(2rem, 6vw, 3rem) clamp(1rem, 6vw, 5rem) 3rem;
-        display: grid;
-        gap: 0.5rem;
-        color: var(--muted);
-        font-size: 0.95rem;
-      }
-
-      .keywords {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-        margin-top: 1rem;
-      }
-
-      .keyword {
-        border-radius: 999px;
-        padding: 0.4rem 0.8rem;
-        background: rgba(17, 24, 39, 0.06);
-        font-size: 0.85rem;
-        color: var(--foreground);
-      }
-
-      @media (prefers-color-scheme: dark) {
-        :root {
-          --background: #020617;
-          --foreground: #f8fafc;
-          --accent: #f8fafc;
-          --accent-foreground: #020617;
-          --muted: #cbd5f5;
-          --card: rgba(15, 23, 42, 0.6);
-          --card-border: rgba(248, 250, 252, 0.1);
-        }
-
-        article {
-          background: linear-gradient(145deg, rgba(15, 23, 42, 0.72), rgba(2, 6, 23, 0.88));
-        }
-
-        .full-post {
-          background: linear-gradient(145deg, rgba(15, 23, 42, 0.78), rgba(2, 6, 23, 0.92));
-        }
-
-        .full-post code,
-        .full-post pre {
-          background: rgba(248, 250, 252, 0.08);
-        }
-
-        .keyword {
-          background: rgba(248, 250, 252, 0.1);
-          color: var(--accent-foreground);
-        }
-      }
-    </style>
+    <link rel="stylesheet" href="./assets/styles.css" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -323,7 +64,7 @@
             "inLanguage": ["en", "bn"],
             "datePublished": "2024-05-10",
             "description": "Designing a minimalist, responsive landing page with semantic HTML and CSS.",
-            "url": "https://sheikhcoders.github.io/#portfolio-landing"
+            "url": "https://sheikhcoders.github.io/blog/portfolio-landing.html"
           },
           {
             "@type": "BlogPosting",
@@ -331,7 +72,7 @@
             "inLanguage": ["en", "bn"],
             "datePublished": "2024-05-18",
             "description": "Understand how URL query parameters drive segmentation, tracking, and SEO logic with bilingual guidance.",
-            "url": "https://sheikhcoders.github.io/#query-string-seo"
+            "url": "https://sheikhcoders.github.io/blog/query-string-seo.html"
           },
           {
             "@type": "BlogPosting",
@@ -339,7 +80,7 @@
             "inLanguage": ["en", "bn"],
             "datePublished": "2024-04-28",
             "description": "Quick performance checklist for new Next.js projects covering SEO and UX essentials.",
-            "url": "https://sheikhcoders.github.io/#nextjs-performance"
+            "url": "https://sheikhcoders.github.io/blog/nextjs-performance.html"
           },
           {
             "@type": "BlogPosting",
@@ -347,7 +88,7 @@
             "inLanguage": ["en", "bn"],
             "datePublished": "2024-04-12",
             "description": "How to co-create helpful documentation with AI while keeping your voice clear and focused.",
-            "url": "https://sheikhcoders.github.io/#ai-writing"
+            "url": "https://sheikhcoders.github.io/blog/ai-writing-workflow.html"
           },
           {
             "@type": "BlogPosting",
@@ -355,7 +96,7 @@
             "inLanguage": ["en", "bn"],
             "datePublished": "2024-06-02",
             "description": "Step-by-step workflow automation for building and deploying Next.js from GitHub Actions.",
-            "url": "https://sheikhcoders.github.io/#nextjs-github-actions"
+            "url": "https://sheikhcoders.github.io/blog/nextjs-github-actions.html"
           }
         ]
       }
@@ -391,7 +132,11 @@
             <span class="keyword">Minimal CSS</span>
             <span class="keyword">SEO Basics</span>
           </div>
-          <a class="read-more" href="#post-portfolio-landing" aria-label="Read the full Portfolio Landing Page article">
+          <a
+            class="read-more"
+            href="./blog/portfolio-landing.html"
+            aria-label="Read the full Portfolio Landing Page article"
+          >
             <span>Read full article</span>
             <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
               <path d="M5 12h14M13 6l6 6-6 6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
@@ -414,7 +159,11 @@
             <span class="keyword">SEO Logic</span>
             <span class="keyword">Analytics</span>
           </div>
-          <a class="read-more" href="#post-query-string-seo" aria-label="Read the full Query String SEO article">
+          <a
+            class="read-more"
+            href="./blog/query-string-seo.html"
+            aria-label="Read the full Query String SEO article"
+          >
             <span>Read full article</span>
             <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
               <path d="M5 12h14M13 6l6 6-6 6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
@@ -437,7 +186,11 @@
             <span class="keyword">Core Web Vitals</span>
             <span class="keyword">Meta Tags</span>
           </div>
-          <a class="read-more" href="#post-nextjs-performance" aria-label="Read the full Next.js performance article">
+          <a
+            class="read-more"
+            href="./blog/nextjs-performance.html"
+            aria-label="Read the full Next.js performance article"
+          >
             <span>Read full article</span>
             <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
               <path d="M5 12h14M13 6l6 6-6 6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
@@ -460,7 +213,11 @@
             <span class="keyword">Technical Writing</span>
             <span class="keyword">Productivity</span>
           </div>
-          <a class="read-more" href="#post-ai-writing" aria-label="Read the full AI writing workflow article">
+          <a
+            class="read-more"
+            href="./blog/ai-writing-workflow.html"
+            aria-label="Read the full AI writing workflow article"
+          >
             <span>Read full article</span>
             <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
               <path d="M5 12h14M13 6l6 6-6 6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
@@ -481,7 +238,11 @@
             <span class="keyword">Next.js Deploy</span>
             <span class="keyword">CI/CD</span>
           </div>
-          <a class="read-more" href="#post-nextjs-actions" aria-label="Read the full Next.js GitHub Actions article">
+          <a
+            class="read-more"
+            href="./blog/nextjs-github-actions.html"
+            aria-label="Read the full Next.js GitHub Actions article"
+          >
             <span>Read full article</span>
             <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
               <path d="M5 12h14M13 6l6 6-6 6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
@@ -489,193 +250,29 @@
           </a>
         </article>
       </section>
-      <section aria-labelledby="query-string-guide" style="margin-top: clamp(2.5rem, 8vw, 4rem); display: grid; gap: 1rem;">
-        <h2 id="query-string-guide">Query String Deep Dive (English &amp; Bangla)</h2>
+      <section class="section-intro" aria-label="Why this blog matters">
+        <h2>SEO-first notes crafted for quick action</h2>
         <p lang="en">
-          A URL query string starts after a <code>?</code> and carries key-value pairs such as
-          <code>utm_source=newsletter</code>. These parameters help filter content, power search experiences, and pass
-          analytics insights without changing the core page.
+          Every article goes beyond highlights with bilingual breakdowns, mobile-first audits, and metadata checklists so your
+          shipping momentum never slows.
         </p>
         <p class="bangla" lang="bn">
-          একটি ইউআরএল কুয়েরি স্ট্রিং <code>?</code> চিহ্নের পরে শুরু হয় এবং <code>utm_source=newsletter</code>
-          এর মতো কী-ভ্যালু জোড়া বহন করে। এসব প্যারামিটার কনটেন্ট ফিল্টার করতে, সার্চের ফল উন্নত করতে এবং মূল
-          পৃষ্ঠাটি অপরিবর্তিত রেখে অ্যানালিটিক্স তথ্য পাঠাতে সহায়তা করে।
+          প্রতিটি নিবন্ধে ইংরেজি ও বাংলায় বিশ্লেষণ, মোবাইল-ফার্স্ট অডিট এবং মেটাডাটা চেকলিস্ট দেয়া থাকে যাতে কাজের গতি কমে না।
         </p>
-        <div style="display: grid; gap: 0.75rem;">
-          <div>
-            <h3 style="margin: 0; font-size: 1.1rem;">Focused SEO Checklist</h3>
-            <ul style="margin: 0; padding-left: 1.2rem;">
-              <li lang="en">Use readable keys (<code>category=css</code>) so crawlers understand content groupings.</li>
-              <li class="bangla" lang="bn">ডাইনামিক প্যারামিটারকে গুগল সার্চ কনসোলে ডিফাইন করে ডুপ্লিকেট কনটেন্টের ঝুঁকি কমান।</li>
-              <li lang="en">Pair canonical URLs with query variants to preserve ranking signals.</li>
-              <li class="bangla" lang="bn">অ্যানালিটিক্স ট্র্যাকিং (যেমন <code>utm_</code>) শেষ হলে অপ্রয়োজনীয় প্যারামিটার অপসারণ করুন।</li>
-            </ul>
-          </div>
-          <div>
-            <h3 style="margin: 0; font-size: 1.1rem;">Logic Flow for Dynamic Pages</h3>
-            <ol style="margin: 0; padding-left: 1.2rem;">
-              <li lang="en">Parse the query string with built-in browser APIs like <code>URLSearchParams</code>.</li>
-              <li class="bangla" lang="bn">ফিল্টার প্রয়োগের আগে ডিফল্ট মান সেট করে মোবাইল ব্যবহারকারীর জন্য দ্রুত লোড নিশ্চিত করুন।</li>
-              <li lang="en">Cache popular combinations to keep mobile latency low and UX focused.</li>
-            </ol>
-          </div>
+        <div class="note-box" lang="en">
+          <strong>Micro SEO wins:</strong> internal linking, structured data, and performance budgets are embedded in every guide.
         </div>
-      </section>
-      <section class="full-posts" aria-label="Complete blog articles">
-        <article class="full-post" id="post-portfolio-landing">
-          <h3>Build a Clean Portfolio Landing Page</h3>
-          <section aria-label="English article" lang="en">
-            <p>
-              Start with semantic containers (<code>&lt;header&gt;</code>, <code>&lt;main&gt;</code>, <code>&lt;footer&gt;</code>) so screen
-              readers and search engines map the layout without guesswork. Keep the hero section concise with a primary CTA and
-              a muted secondary link for recruiters who prefer quick scans.
-            </p>
-            <ul>
-              <li>Use fluid typography via <code>clamp()</code> to maintain readability from 320px to desktop screens.</li>
-              <li>Compress preview imagery with <code>&lt;picture&gt;</code> and <code>loading="lazy"</code> attributes to stay under 100&nbsp;KB.</li>
-              <li>Ship Open Graph and Twitter meta tags that match your hero copy for consistent sharing.</li>
-            </ul>
-          </section>
-          <section aria-label="Bangla article" class="bangla" lang="bn">
-            <p>
-              শুরুতেই সেমান্টিক এলিমেন্ট (<code>&lt;header&gt;</code>, <code>&lt;main&gt;</code>, <code>&lt;footer&gt;</code>) ব্যবহার করলে স্ক্রিন রিডার এবং
-              সার্চ ইঞ্জিন লেআউট সহজে বুঝতে পারে। হিরো সেকশনে একটি প্রধান কল-টু-অ্যাকশন এবং দ্রুত স্ক্যান পছন্দ করা রিক্রুটারদের জন্য একটি
-              সেকেন্ডারি লিঙ্ক রাখুন।
-            </p>
-            <ul>
-              <li><code>clamp()</code> টাইপোগ্রাফি ব্যবহার করে ৩২০ পিক্সেল থেকে ডেস্কটপ পর্যন্ত পাঠযোগ্যতা বজায় রাখুন।</li>
-              <li><code>&lt;picture&gt;</code> ও <code>loading="lazy"</code> দিয়ে প্রিভিউ ইমেজ ১০০ কিলোবাইটের মধ্যে সংকুচিত রাখুন।</li>
-              <li>ওপেন গ্রাফ ও টুইটার মেটা ট্যাগে হিরো কপির সঙ্গে সামঞ্জস্যপূর্ণ বার্তা দিন যাতে শেয়ারের সময় ভিজুয়াল এক থাকে।</li>
-            </ul>
-          </section>
-        </article>
-        <article class="full-post" id="post-query-string-seo">
-          <h3>Mastering URL Query Strings for Focused SEO</h3>
-          <section aria-label="English article" lang="en">
-            <p>
-              When you expose filters or campaign parameters, document them in your analytics playbook and Search Console settings.
-              This prevents duplicate crawling and keeps reports aligned with marketing goals.
-            </p>
-            <ol>
-              <li>Whitelist marketing keys like <code>utm_medium</code>, <code>campaign</code>, and <code>ref</code> in canonical logic.</li>
-              <li>Reject untrusted parameters server-side to block cache poisoning and reduce bundle re-renders.</li>
-              <li>Log query combinations and sort by conversions to prune low-impact URLs every quarter.</li>
-            </ol>
-          </section>
-          <section aria-label="Bangla article" class="bangla" lang="bn">
-            <p>
-              ফিল্টার বা ক্যাম্পেইন প্যারামিটার ব্যবহার করলে অ্যানালিটিক্স প্লেবুক এবং সার্চ কনসোল সেটিংসে স্পষ্ট করে উল্লেখ করুন। এতে ডুপ্লিকেট ক্রলিং
-              কমে এবং রিপোর্ট মার্কেটিং লক্ষ্য অনুযায়ী থাকে।
-            </p>
-            <ol>
-              <li>ক্যানোনিকাল সেটআপে <code>utm_medium</code>, <code>campaign</code>, <code>ref</code> এর মতো মার্কেটিং কী প্রাধান্য দিন।</li>
-              <li>সার্ভার সাইডে অবিশ্বস্ত প্যারামিটার বাতিল করুন যাতে ক্যাশ পয়জনিং ও অপ্রয়োজনীয় রি-রেন্ডার কমে।</li>
-              <li>প্রতি কোয়ার্টারে কোয়েরি কম্বিনেশন লগ বিশ্লেষণ করে কম পারফর্ম করা ইউআরএল কেটে দিন।</li>
-            </ol>
-          </section>
-        </article>
-        <article class="full-post" id="post-nextjs-performance">
-          <h3>Starter Guide to Next.js Performance</h3>
-          <section aria-label="English article" lang="en">
-            <p>
-              Embrace the <code>app/</code> router for automatic code-splitting and metadata APIs. Add <code>next/font</code> for critical font
-              inlining and use <code>Image</code> for responsive asset delivery without cumulative layout shift.
-            </p>
-            <ul>
-              <li>Enable <code>experimental.optimizePackageImports</code> to trim unused library code in production.</li>
-              <li>Measure Core Web Vitals via <code>reportWebVitals</code> and push results to your preferred analytics endpoint.</li>
-              <li>Create a Lighthouse CI budget (largest contentful paint &lt; 2.5s, total blocking time &lt; 200ms) before launch.</li>
-            </ul>
-          </section>
-          <section aria-label="Bangla article" class="bangla" lang="bn">
-            <p>
-              স্বয়ংক্রিয় কোড স্প্লিটিং ও মেটাডাটা এপিআই পেতে <code>app/</code> রাউটার ব্যবহার করুন। <code>next/font</code> দিয়ে ক্রিটিকাল ফন্ট ইনলাইন করুন এবং
-              <code>Image</code> কম্পোনেন্ট ব্যবহার করলে রেস্পন্সিভ ইমেজ সহজে পরিবেশন হয়।
-            </p>
-            <ul>
-              <li>প্রোডাকশনে অব্যবহৃত লাইব্রেরি কোড কমাতে <code>experimental.optimizePackageImports</code> সক্রিয় করুন।</li>
-              <li><code>reportWebVitals</code> ব্যবহার করে কোর ওয়েব ভাইটালস মাপুন এবং পছন্দের অ্যানালিটিক্স এন্ডপয়েন্টে পাঠান।</li>
-              <li>লাইভ করার আগে লাইটহাউস সি আই বাজেট সেট করুন (LCP &lt; ২.৫ সেকেন্ড, TBT &lt; ২০০ মিলিসেকেন্ড)।</li>
-            </ul>
-          </section>
-        </article>
-        <article class="full-post" id="post-ai-writing">
-          <h3>AI Writing Workflow for Developers</h3>
-          <section aria-label="English article" lang="en">
-            <p>
-              Draft outlines with prompts that specify reader level, tone, and context. Iterate by reviewing AI suggestions against your
-              project requirements, then store final snippets in a shared knowledge base.
-            </p>
-            <ul>
-              <li>Tag AI-generated changes in version control for transparent peer reviews.</li>
-              <li>Keep a reusable prompt library for changelog updates, release notes, and onboarding guides.</li>
-              <li>Automate grammar checks with CI jobs so documentation stays consistent across repos.</li>
-            </ul>
-          </section>
-          <section aria-label="Bangla article" class="bangla" lang="bn">
-            <p>
-              পাঠকের স্তর, টোন ও কনটেক্সট উল্লেখ করে প্রম্পট তৈরি করলে এআই আউটলাইন স্পষ্ট হয়। প্রকল্পের প্রয়োজনীয়তার সাথে মিলিয়ে পরামর্শ যাচাই করুন
-              এবং চূড়ান্ত নোট শেয়ার্ড নলেজ বেসে সংরক্ষণ করুন।
-            </p>
-            <ul>
-              <li>পিয়ার রিভিউ সহজ করতে এআই-জেনারেটেড পরিবর্তন ভার্সন কন্ট্রোলে আলাদা ট্যাগ দিন।</li>
-              <li>চেঞ্জলগ, রিলিজ নোট ও অনবোর্ডিং গাইডের জন্য পুনঃব্যবহারযোগ্য প্রম্পট লাইব্রেরি রাখুন।</li>
-              <li>ডকুমেন্টেশন ধারাবাহিক রাখতে সি আই জবের মাধ্যমে গ্রামার চেক অটোমেট করুন।</li>
-            </ul>
-          </section>
-        </article>
-        <article class="full-post" id="post-nextjs-actions">
-          <h3>Deploy Next.js with GitHub Actions</h3>
-          <section aria-label="English article" lang="en">
-            <p>
-              GitHub Actions can build, test, and deploy your Next.js project whenever you push to the main branch. The workflow below
-              installs dependencies with caching, runs unit tests, builds the production bundle, and publishes to Vercel via a deploy hook.
-            </p>
-            <pre><code>name: Deploy Next.js
-
-on:
-  push:
-    branches: ["main"]
-
-jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      deployments: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run test -- --watch=false
-      - run: npm run build
-      - name: Trigger Vercel Deploy Hook
-        run: curl -X POST "$VERCEL_DEPLOY_HOOK"</code></pre>
-            <p>
-              Store <code>VERCEL_DEPLOY_HOOK</code> as an encrypted repository secret. If you publish static exports, replace the last step with a
-              <code>actions/upload-pages-artifact</code> and <code>actions/deploy-pages</code> pair targeting GitHub Pages.
-            </p>
-          </section>
-          <section aria-label="Bangla article" class="bangla" lang="bn">
-            <p>
-              যখনই আপনি মেইন ব্রাঞ্চে পুশ করবেন, গিটহাব অ্যাকশন্স নেক্সট.জেএস প্রজেক্টের ডিপেন্ডেন্সি ইনস্টল, টেস্ট রান এবং বিল্ড তৈরি করতে পারে। নিচের
-              ওয়ার্কফ্লোটি ক্যাশ সহ ডিপেন্ডেন্সি ইনস্টল, ইউনিট টেস্ট, প্রোডাকশন বিল্ড এবং ভার্সেল ডিপ্লয় হুক ট্রিগার করে।
-            </p>
-            <p>
-              <code>VERCEL_DEPLOY_HOOK</code> সিক্রেট হিসেবে সংরক্ষণ করুন। যদি স্ট্যাটিক এক্সপোর্ট ব্যবহার করেন তবে শেষ ধাপে গিটহাব পেজেসের জন্য
-              <code>actions/upload-pages-artifact</code> এবং <code>actions/deploy-pages</code> স্টেপ ব্যবহার করুন।
-            </p>
-            <ul>
-              <li>নিজস্ব ডোমেইন সংযোগের আগে প্রিভিউ পরিবেশে বিল্ড চেক করুন।</li>
-              <li>ডিপ্লয়মেন্ট ব্যর্থ হলে <code>workflow_run</code> ইভেন্ট দিয়ে রোলব্যাক ট্রিগার করতে পারেন।</li>
-              <li>আরো নিরাপত্তার জন্য এনভায়রনমেন্ট প্রোটেকশন রুলস ও রিভিউয়ার অ্যাপ্রুভাল যুক্ত করুন।</li>
-            </ul>
-          </section>
-        </article>
+        <div class="note-box bangla" lang="bn">
+          <strong>ক্ষুদ্র এসইও সাফল্য:</strong> প্রতিটি গাইডে ইন্টারনাল লিঙ্কিং, স্ট্রাকচার্ড ডাটা ও পারফরমেন্স বাজেট নিয়ে ধাপে ধাপে নির্দেশনা রয়েছে।
+        </div>
+        <ul>
+          <li lang="en">Mobile responsive layouts validated on 320px, 768px, and desktop breakpoints.</li>
+          <li class="bangla" lang="bn">৩২০, ৭৬৮ ও ডেস্কটপ ব্রেকপয়েন্টে মোবাইল রেস্পন্সিভ লেআউট যাচাই করা হয়েছে।</li>
+          <li lang="en">Bangla translations emphasize context-sensitive terms for regional search intent.</li>
+          <li class="bangla" lang="bn">বাংলা অনুবাদে অঞ্চলভিত্তিক সার্চ ইন্টেন্ট বোঝাতে প্রাসঙ্গিক শব্দ ব্যবহার করা হয়েছে।</li>
+          <li lang="en">Practical checklists you can drop into project retros, sprint planning, or onboarding docs.</li>
+          <li class="bangla" lang="bn">প্রজেক্ট রেট্রো, স্প্রিন্ট পরিকল্পনা বা অনবোর্ডিং ডকে সরাসরি যোগ করার জন্য ব্যবহারিক চেকলিস্ট।</li>
+        </ul>
       </section>
     </main>
     <footer>


### PR DESCRIPTION
## Summary
- add a shared stylesheet to drive mobile-first theming for the blog
- update the homepage to link to individual blog posts and highlight SEO value props
- create standalone bilingual blog pages with structured metadata for each post

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_b_68e03663284883328217e88b551056d4